### PR TITLE
Add more filters to the time_entries() function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Hide `time_format` function in the documentation
 * Hide `time_parse` function in the documentation
+* Add the ability to filter time entries by `description`, `project`, `task`, or `tag`.
 
 # {clockify} 0.0.9
 

--- a/man/time_entries.Rd
+++ b/man/time_entries.Rd
@@ -8,6 +8,10 @@ time_entries(
   user_id = NULL,
   start = NULL,
   end = NULL,
+  description = NULL,
+  project = NULL,
+  task = NULL,
+  tags = NULL,
   finished = TRUE,
   concise = TRUE,
   ...
@@ -16,9 +20,17 @@ time_entries(
 \arguments{
 \item{user_id}{User ID}
 
-\item{start}{Start time}
+\item{start}{If provided, only time entries that started after the specified datetime will be returned.}
 
-\item{end}{End time}
+\item{end}{If provided, only time entries that started before the specified datetime will be returned.}
+
+\item{description}{If provided, time entries will be filtered by description.}
+
+\item{project}{If provided, time entries will be filtered by project.}
+
+\item{task}{If provided, time entries will be filtered by task.}
+
+\item{tags}{If provided, time entries will be filtered by tags. You can provide one or more tags.}
 
 \item{finished}{Whether to include only finished time intervals (intervals with both start and end time)}
 
@@ -30,7 +42,7 @@ time_entries(
 A data frame with one record per time entry.
 }
 \description{
-Get time entries
+You send time according to your account's timezone (from Profile Settings) and get response with time in UTC.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
## Description

Adds the ability to filter time entries by `description`, `project`, `task`, or `tag`.

Example:
```r
set_api_key(Sys.getenv("CLOCKIFY_API_KEY"))

time_entries(
  user_id = "612b15a4f4c3bf0462192676",
  description = "Fix escaping bug"
)
```

## ✅ Checks

- [ ] Adheres to code style
- [ ] All tests pass
- [ ] Documentation updated
