### PR TITLE
feat: Retain tag list in time_entries

### DIFF
--- a/R/time-entry.R
+++ b/R/time-entry.R
@@ -5,6 +5,7 @@ EMPTY_ENTRIES <- tibble(
   project_id = character(),
   billable = logical(),
   description = character(),
+  tag_ids = list(),
   time_start = POSIXct(),
   time_end = POSIXct(),
   duration = numeric()
@@ -23,6 +24,7 @@ parse_time_entries <- function(entries, finished, concise) {
         project_id,
         billable,
         description,
+        tag_ids,
         time_start = start,
         time_end = end
       ) %>%


### PR DESCRIPTION
## Description
When parsing time entries, any tags associated with the entries are stored in a list. 
This allows for custom sorting, grouping and analysis when creating reports.

Note: I did not add the `tag_ids` list to the `parse_time_entries(concise=TRUE)` output.

## ✅ Checks

- [x] Adheres to code style
- [ ] All tests pass # I could not run the tests. Happy to be shown how. 
- [ ] Documentation updated # The changes did not modify any documented functions
